### PR TITLE
BEP-42: DHT security extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,15 @@
     "k-bucket": "^0.4.2",
     "once": "^1.3.1",
     "run-parallel": "^1.0.0",
-    "string2compact": "^1.1.1"
+    "string2compact": "^1.1.1",
+    "ip": "^0.3.2",
+    "fast-crc32c": "^0.1.3"
   },
   "devDependencies": {
     "ip": "^0.3.0",
     "standard": "^2.0.0",
-    "tape": "^2.12.3"
+    "tape": "^2.12.3",
+    "chance": "^0.7.3"
   },
   "homepage": "http://webtorrent.io",
   "keywords": [

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,20 +1,7 @@
 var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
-
-test('explicitly set nodeId', function (t) {
-  var nodeId = common.randomId()
-
-  var dht = new DHT({
-    nodeId: nodeId,
-    bootstrap: false
-  })
-
-  common.failOnWarningOrError(t, dht)
-
-  t.equal(dht.nodeId, nodeId)
-  t.end()
-})
+var Chance = require('chance')
 
 test('`ping` query send and response', function (t) {
   t.plan(2)
@@ -37,7 +24,9 @@ test('`ping` query send and response', function (t) {
 
 test('`find_node` query for exact match (with one in table)', function (t) {
   t.plan(3)
-  var targetNodeId = common.randomId()
+
+  var targetAddr = '255.255.255.255:6969'
+  var targetNodeId = DHT.generateNodeId(targetAddr)
 
   var dht1 = new DHT({ bootstrap: false })
   var dht2 = new DHT({ bootstrap: false })
@@ -45,7 +34,7 @@ test('`find_node` query for exact match (with one in table)', function (t) {
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode('255.255.255.255:6969', targetNodeId)
+  dht1.addNode(targetAddr, targetNodeId)
 
   dht1.listen(function (port) {
     dht2._sendFindNode('127.0.0.1:' + port, targetNodeId, function (err, res) {
@@ -53,7 +42,7 @@ test('`find_node` query for exact match (with one in table)', function (t) {
       t.deepEqual(res.id, dht1.nodeId)
       t.deepEqual(
         res.nodes.map(function (node) { return node.addr }),
-        [ '255.255.255.255:6969', '127.0.0.1:' + dht2.port ]
+        [ targetAddr, '127.0.0.1:' + dht2.port ]
       )
 
       dht1.destroy()
@@ -70,9 +59,13 @@ test('`find_node` query (with many in table)', function (t) {
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode('1.1.1.1:6969', common.randomId())
-  dht1.addNode('10.10.10.10:6969', common.randomId())
-  dht1.addNode('255.255.255.255:6969', common.randomId())
+  var addrs = ['1.1.1.1:6969',
+               '10.10.10.10:6969',
+               '255.255.255.255:6969']
+
+  addrs.forEach(function (addr) {
+    dht1.addNode(addr, DHT.generateNodeId(addr))
+  })
 
   dht1.listen(function (port) {
     var targetNodeId = common.randomId()
@@ -81,8 +74,7 @@ test('`find_node` query (with many in table)', function (t) {
       t.deepEqual(res.id, dht1.nodeId)
       t.deepEqual(
         res.nodes.map(function (node) { return node.addr }).sort(),
-        [ '1.1.1.1:6969', '10.10.10.10:6969', '127.0.0.1:' + dht2.port,
-          '255.255.255.255:6969' ]
+        addrs.concat(['127.0.0.1:' + dht2.port]).sort()
       )
 
       dht1.destroy()
@@ -99,8 +91,10 @@ test('`get_peers` query to node with *no* peers in table', function (t) {
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode('1.1.1.1:6969', common.randomId())
-  dht1.addNode('2.2.2.2:6969', common.randomId())
+  var addrs = ['1.1.1.1:6969', '2.2.2.2:6969']
+
+  dht1.addNode(addrs[0], DHT.generateNodeId(addrs[0]))
+  dht1.addNode(addrs[1], DHT.generateNodeId(addrs[1]))
 
   dht1.listen(function (port) {
     var targetInfoHash = common.randomId()
@@ -110,7 +104,7 @@ test('`get_peers` query to node with *no* peers in table', function (t) {
       t.ok(Buffer.isBuffer(res.token))
       t.deepEqual(
         res.nodes.map(function (node) { return node.addr }).sort(),
-        [ '1.1.1.1:6969', '127.0.0.1:' + dht2.port, '2.2.2.2:6969' ]
+        addrs.concat(['127.0.0.1:' + dht2.port]).sort()
       )
 
       dht1.destroy()
@@ -199,4 +193,55 @@ test('`announce_peer` query gets ack response', function (t) {
       )
     })
   })
+})
+
+// test vectors at http://www.bittorrent.org/beps/bep_0042.html
+test('test vectors for node ID generation', function (t) {
+  t.plan(5)
+
+  var ips = ['124.31.75.21',
+             '21.75.31.124',
+             '65.23.51.170',
+             '84.124.73.14',
+             '43.213.53.83']
+
+  var randoms = [1, 86, 22, 65, 90]
+
+  var ids = ['5fbfbff10c5d6a4ec8a88e4c6ab4c28b95eee401',
+             '5a3ce9c14e7a08645677bbd1cfe7d8f956d53256',
+             'a5d43220bc8f112a3d426c84764f8c2a1150e616',
+             '1b0321dd1bb1fe518101ceef99462b947a01ff41',
+             'e56f6cbf5b7c4be0237986d5243b87aa6d51305a']
+
+  for (var i = 0; i < 5; i++) {
+    var prefix = DHT.calculateIdPrefix(ips[i], randoms[i] & 0x7)
+    t.ok(DHT.idPrefixMatches(prefix, ids[i]),
+      'expected: ' + prefix.toString('hex') +
+      'actual id: ' + ids[i].toString('hex'))
+  }
+})
+
+test('generate and validate node IDs for IPv4 and IPv6', function (t) {
+  var numAddresses = 100
+  var idsPerAddr = 100
+  var chance = new Chance()
+
+  t.plan(1)
+
+  var idsValid = []
+
+  for (var i = 0; i < numAddresses; i++) {
+    var addr4 = chance.ip()
+    var addr6 = chance.ipv6()
+
+    for (var j = 0; j < idsPerAddr; j++) {
+      var id4 = DHT.generateNodeId(addr4)
+      idsValid.push(DHT.isValidNodeId(addr4, id4))
+
+      var id6 = DHT.generateNodeId(addr6)
+      idsValid.push(DHT.isValidNodeId(addr6, id6))
+    }
+  }
+
+  t.ok(idsValid.every(function (v) { return v }))
 })


### PR DESCRIPTION
http://www.bittorrent.org/beps/bep_0042.html. this PR is just for review; it's definitely not complete. 

some stuff to sort out:
- setting the DHT node ID: it seems like `socket.createSocket` happens async and calling `socket.address()` in the constructor causes an exception. setting the node ID in `socket.on 'listening'` is problematic because other stuff like `_debug` also uses nodeId. is there another way to get the address?
- what to do when we think our node ID may be incorrect -- e.g., you receive messages with `ip` field different from you think yours is -- libtorrent doesn't seem to do anything about this
- what else to do if we see nodes with invalid node ids -- right now it just refrains from adding the node to the routing table.

@feross 