### PR TITLE
seq put fix

### DIFF
--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -466,7 +466,7 @@ test('sequence', function (t) {
   common.failOnWarningOrError(t, dht0)
   common.failOnWarningOrError(t, dht1)
 
-  dht0.on('ready', function () {
+  dht0.on('node', function () {
     var opts0 = {
       k: keypair.publicKey,
       sign: sign(keypair),
@@ -479,15 +479,13 @@ test('sequence', function (t) {
       seq: 4,
       v: Buffer(500).fill('4')
     }
-    var hash0, hash1
+    var hash0
 
     dht0.put(opts0, function (errors, hash) {
       errors.forEach(t.error.bind(t))
       hash0 = hash
       dht0.put(opts1, function (errors, hash) {
-        errors.forEach(t.error.bind(t))
-        hash1 = hash
-        t.deepEqual(hash0, hash1)
+        t.ok(errors.length, 'caught expected error: ' + errors[0])
         check()
       })
     })

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -446,6 +446,66 @@ test('mutable update mesh', function (t) {
   }
 })
 
+test('sequence', function (t) {
+  t.plan(4)
+
+  var keypair = ed.createKeyPair(ed.createSeed())
+
+  var dht0 = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht1 = new DHT({ bootstrap: false, verify: ed.verify })
+  dht0.listen(0, function () {
+    dht1.addNode('127.0.0.1:' + dht0.address().port)
+  })
+  dht1.listen(0, function () {
+    dht0.addNode('127.0.0.1:' + dht1.address().port)
+  })
+  t.once('end', function () {
+    dht0.destroy()
+    dht1.destroy()
+  })
+  common.failOnWarningOrError(t, dht0)
+  common.failOnWarningOrError(t, dht1)
+
+  dht0.on('ready', function () {
+    var opts0 = {
+      k: keypair.publicKey,
+      sign: sign(keypair),
+      seq: 5,
+      v: Buffer(500).fill('5')
+    }
+    var opts1 = {
+      k: keypair.publicKey,
+      sign: sign(keypair),
+      seq: 4,
+      v: Buffer(500).fill('4')
+    }
+    var hash0, hash1
+
+    dht0.put(opts0, function (errors, hash) {
+      errors.forEach(t.error.bind(t))
+      hash0 = hash
+      dht0.put(opts1, function (errors, hash) {
+        errors.forEach(t.error.bind(t))
+        hash1 = hash
+        t.deepEqual(hash0, hash1)
+        check()
+      })
+    })
+
+    function check () {
+      dht1.get(hash0, function (err, res) {
+        t.ifError(err)
+        t.deepEqual(
+          res.v.toString('utf8'),
+          Buffer(500).fill('5').toString('utf8'),
+          'greater sequence expected'
+        )
+        t.equal(res.seq, 5)
+      })
+    }
+  })
+})
+
 function fill (n, s) {
   var bs = Buffer(s)
   var b = new Buffer(n)

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -471,13 +471,13 @@ test('invalid sequence', function (t) {
       k: keypair.publicKey,
       sign: sign(keypair),
       seq: 5,
-      v: Buffer(500).fill('5')
+      v: fill(500, '5')
     }
     var opts1 = {
       k: keypair.publicKey,
       sign: sign(keypair),
       seq: 4,
-      v: Buffer(500).fill('4')
+      v: fill(500, '4')
     }
     var hash0
 
@@ -495,7 +495,7 @@ test('invalid sequence', function (t) {
         t.ifError(err)
         t.deepEqual(
           res.v.toString('utf8'),
-          Buffer(500).fill('5').toString('utf8'),
+          fill(500, '5').toString('utf8'),
           'greater sequence expected'
         )
         t.equal(res.seq, 5)
@@ -529,13 +529,13 @@ test('valid sequence', function (t) {
       k: keypair.publicKey,
       sign: sign(keypair),
       seq: 4,
-      v: Buffer(500).fill('4')
+      v: fill(500, '4')
     }
     var opts1 = {
       k: keypair.publicKey,
       sign: sign(keypair),
       seq: 5,
-      v: Buffer(500).fill('5')
+      v: fill(500, '5')
     }
     var hash0, hash1
 
@@ -555,7 +555,7 @@ test('valid sequence', function (t) {
         t.ifError(err)
         t.deepEqual(
           res.v.toString('utf8'),
-          Buffer(500).fill('5').toString('utf8'),
+          fill(500, '5').toString('utf8'),
           'greater sequence expected'
         )
         t.equal(res.seq, 5)


### PR DESCRIPTION
This patch adds some tests for sequences and should fix #66. Previously, the hash was used for lookups before it was computed.