### PR TITLE
fix immutable put/gets

### DIFF
--- a/test/dht_store_immutable.js
+++ b/test/dht_store_immutable.js
@@ -18,7 +18,7 @@ test('local immutable put/get', function (t) {
 
       t.equal(
         hash.toString('hex'),
-        '3ab87d68b1be9dc63da13faf18a7d2376ccd938a' // sha1 of the value
+        '3a34a097641348623d123acfba3aa589028f241e' // sha1 of the value
       )
       dht.get(hash, function (err, res) {
         t.ifError(err)
@@ -61,7 +61,7 @@ test('multi-party immutable put/get', function (t) {
 
       t.equal(
         hash.toString('hex'),
-        '3ab87d68b1be9dc63da13faf18a7d2376ccd938a' // sha1 of the value
+        '3a34a097641348623d123acfba3aa589028f241e' // sha1 of the value
       )
       dht2.get(hash, function (err, res) {
         t.ifError(err)


### PR DESCRIPTION
this should fix BEP44 when putting/getting keys in the public bittorrent dht which currently doesn't work.

the spec is vague on how putting of keys work but after reading the libtorrent source code and pinging some bittorrent devs on irc it turns out you should do a .get before doing a .put and echoing the token back (similar to how announce works).