### PR TITLE
.lookup returns abort function

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ terminated, and is called with two paramaters. The first is an `Error` or null. 
 is an array of the K closest nodes. You usually don't need to use this info and can simply
 listen for `peer` events.
 
+Returns an `abort()` function that would allow us to abort the query.
 
 #### `dht.listen([port], [address], [onlistening])`
 

--- a/client.js
+++ b/client.js
@@ -285,6 +285,7 @@ DHT.prototype.lookup = function (infoHash, cb) {
   infoHash = toBuffer(infoHash)
   if (!cb) cb = noop
   var self = this
+  var aborted = false
 
   process.nextTick(emit)
   this._debug('lookup %s', infoHash)
@@ -305,8 +306,11 @@ DHT.prototype.lookup = function (infoHash, cb) {
   }
 
   function onreply (message, node) {
+    if (aborted) return false
     if (message.r.values) emit(message.r.values, node)
   }
+
+  return function abort () { aborted = true }
 }
 
 DHT.prototype.address = function () {


### PR DESCRIPTION
This allows us to abort DHT queries, since they can take huge amounts of time and discover absurdly high count of peers, in most cases we don't need that many but we may need to save traffic.

Refer to issue https://github.com/feross/bittorrent-dht/issues/92

@feross any ideas to how to implement the test for this?