### PR TITLE
Add 'concurrency' to opts documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ If `opts` is specified, then the default options (shown below) will be overridde
 {
   nodeId: '',    // 160-bit DHT node ID (Buffer or hex string, default: randomly generated)
   bootstrap: [], // bootstrap servers (default: router.bittorrent.com:6881, router.utorrent.com:6881, dht.transmissionbt.com:6881)
-  host: false    // host of local peer, if specified then announces get added to local table (String, disabled by default)
+  host: false,    // host of local peer, if specified then announces get added to local table (String, disabled by default)
+  concurrency: 16 // k-rpc option to specify maximum concurrent UDP requests allowed (Number, 16 by default)
 }
 ```
 


### PR DESCRIPTION
This is a good option to have documented.

By the way, 16 might be too much for some old routers, as I've received actual complaints that routers/network crashes after the latest update of bittorrent-dht.

However, I'm going to bet that more than 99% of systems can handle 16 easily, and therefore it's not a viable concern. 

But it's good to have the option documented for anyone with issues