### PR TITLE
change module 'lru' to 'lru-cache'

### DIFF
--- a/client.js
+++ b/client.js
@@ -7,7 +7,7 @@ var KBucket = require('k-bucket')
 var crypto = require('crypto')
 var bencode = require('bencode')
 var equals = require('buffer-equals')
-var LRU = require('lru')
+var LRU = require('lru-cache')
 var debug = require('debug')('bittorrent-dht')
 
 var ROTATE_INTERVAL = 5 * 60 * 1000 // rotate secrets every 5 minutes

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "inherits": "^2.0.1",
     "k-bucket": "^0.6.0",
     "k-rpc": "^3.5.1",
-    "lru": "^1.2.0"
+    "lru-cache": "^4.0.0"
   },
   "devDependencies": {
     "ed25519-supercop": "^1.0.0",


### PR DESCRIPTION
Hi, changing the LRU module from [chriso/lru](https://github.com/chriso/lru) to [isaacs/node-lru-cache](https://github.com/isaacs/node-lru-cache) solves the error described in https://github.com/feross/webtorrent/issues/592. 
The suggested module exposes the exact same API which is in use: `max` and `maxAge` in its constructor properties and naturally the `get`, `set` methods.
Functionality wise - they both perform the same eviction policy - Items are not pro-actively pruned out as they age, but if you try to get an item that is too old, it'll drop it and return undefined instead of giving it to you.
The latter module seems to be more stable, tested and widely used.