### PR TITLE
Use safe-buffer

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,14 +1,15 @@
 module.exports = DHT
 
-var inherits = require('inherits')
-var EventEmitter = require('events').EventEmitter
-var krpc = require('k-rpc')
-var KBucket = require('k-bucket')
-var crypto = require('crypto')
 var bencode = require('bencode')
-var equals = require('buffer-equals')
-var LRU = require('lru')
+var Buffer = require('safe-buffer').Buffer
+var crypto = require('crypto')
 var debug = require('debug')('bittorrent-dht')
+var equals = require('buffer-equals')
+var EventEmitter = require('events').EventEmitter
+var inherits = require('inherits')
+var KBucket = require('k-bucket')
+var krpc = require('k-rpc')
+var LRU = require('lru')
 
 var ROTATE_INTERVAL = 5 * 60 * 1000 // rotate secrets every 5 minutes
 
@@ -166,7 +167,7 @@ DHT.prototype._put = function (opts, cb) {
   if (!cb) cb = noop
 
   var isMutable = !!opts.k
-  var v = typeof opts.v === 'string' ? new Buffer(opts.v) : opts.v
+  var v = typeof opts.v === 'string' ? Buffer.from(opts.v) : opts.v
   var key = isMutable
     ? sha1(opts.salt ? Buffer.concat([opts.salt, opts.k]) : opts.k)
     : sha1(bencode.encode(v))
@@ -571,7 +572,7 @@ DHT.prototype._validateToken = function (host, token) {
 
 DHT.prototype._generateToken = function (host, secret) {
   if (!secret) secret = this._secrets[0]
-  return crypto.createHash('sha1').update(new Buffer(host, 'utf8')).update(secret).digest()
+  return crypto.createHash('sha1').update(Buffer.from(host)).update(secret).digest()
 }
 
 DHT.prototype._rotateSecrets = function () {
@@ -601,7 +602,7 @@ function createGetResponse (id, token, value) {
 }
 
 function encodePeer (host, port) {
-  var buf = new Buffer(6)
+  var buf = Buffer.allocUnsafe(6)
   var ip = host.split('.')
   for (var i = 0; i < 4; i++) buf[i] = parseInt(ip[i] || 0, 10)
   buf.writeUInt16BE(port, 4)
@@ -711,6 +712,6 @@ function pick (values, n) {
 
 function toBuffer (str) {
   if (Buffer.isBuffer(str)) return str
-  if (typeof str === 'string') return new Buffer(str, 'hex')
+  if (typeof str === 'string') return Buffer.from(str, 'hex')
   throw new Error('Pass a buffer or a string')
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "inherits": "^2.0.1",
     "k-bucket": "^3.0.1",
     "k-rpc": "^4.0.0",
-    "lru": "^2.0.0"
+    "lru": "^2.0.0",
+    "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
     "ed25519-supercop": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/feross/bittorrent-dht/issues"
   },
   "dependencies": {
-    "bencode": "^0.9.0",
+    "bencode": "^0.10.0",
     "buffer-equals": "^1.0.3",
     "debug": "^2.2.0",
     "inherits": "^2.0.1",

--- a/test/common.js
+++ b/test/common.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var crypto = require('crypto')
 var ed = require('ed25519-supercop')
 var ip = require('ip')
@@ -41,7 +42,7 @@ exports.addRandomPeers = function (dht, num) {
 
 exports.fill = function (n, s) {
   var bs = Buffer(s)
-  var b = new Buffer(n)
+  var b = Buffer.allocUnsafe(n)
   for (var i = 0; i < n; i++) {
     b[i] = bs[i % bs.length]
   }

--- a/test/internal.js
+++ b/test/internal.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer
 var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
@@ -170,7 +171,7 @@ test('`announce_peer` query with bad token', function (t) {
   var infoHash = common.randomId()
 
   dht1.listen(function () {
-    var token = new Buffer('bad token')
+    var token = Buffer.from('bad token')
     dht2._rpc.query({
       host: '127.0.0.1',
       port: dht1.address().port


### PR DESCRIPTION
Use the new Buffer APIs from Node v6 for added security. For example,
`Buffer.from()` will throw if passed a number, unlike `Buffer()` which
allocated UNINITIALIZED memory in that case.

Use the `safe-buffer` package for compatibility with previous versions
of Node.js, including v4.x, v0.12, and v0.10.

https://github.com/feross/safe-buffer