### PR TITLE
Fix mutable put with salt.

### DIFF
--- a/client.js
+++ b/client.js
@@ -170,7 +170,7 @@ DHT.prototype._put = function (opts, cb) {
   var isMutable = !!opts.k
   var v = typeof opts.v === 'string' ? Buffer.from(opts.v) : opts.v
   var key = isMutable
-    ? this._hash(opts.salt ? Buffer.concat([opts.salt, opts.k]) : opts.k)
+    ? this._hash(opts.salt ? Buffer.concat([opts.k, opts.salt]) : opts.k)
     : this._hash(bencode.encode(v))
 
   var table = this._tables.get(key.toString('hex'))
@@ -259,7 +259,7 @@ DHT.prototype.get = function (key, opts, cb) {
     if (isMutable) {
       if (!verify || !r.sig || !r.k) return true
       if (!verify(r.sig, encodeSigData(r), r.k)) return true
-      if (equals(hash(r.salt ? Buffer.concat([r.salt, r.k]) : r.k), key)) {
+      if (equals(hash(r.salt ? Buffer.concat([r.k, r.salt]) : r.k), key)) {
         value = r
         return false
       }
@@ -490,7 +490,7 @@ DHT.prototype._onput = function (query, peer) {
   if (isMutable && !a.k && !a.sig) return
 
   var key = isMutable
-    ? this._hash(a.salt ? Buffer.concat([a.salt, a.k]) : a.k)
+    ? this._hash(a.salt ? Buffer.concat([a.k, a.salt]) : a.k)
     : this._hash(bencode.encode(v))
   var keyHex = key.toString('hex')
 

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -300,8 +300,8 @@ test('salted multikey multiparty mutable put/get sequence', function (t) {
       v: svalue
     }
 
-    var first = crypto.createHash('sha1').update('first').update(fopts.k).digest()
-    var second = crypto.createHash('sha1').update('second').update(sopts.k).digest()
+    var first = crypto.createHash('sha1').update(fopts.k).update('first').digest()
+    var second = crypto.createHash('sha1').update(sopts.k).update('second').digest()
 
     dht1.put(fopts, function (err, hash) {
       t.error(err)


### PR DESCRIPTION
BEP44:

> The salt can be any binary string (but probably most conveniently a hash of something). This string is appended to the key, as specified in the k field, when calculating the key to store the blob under (i.e. the key get requests specify to retrieve this data).


The salt should be appended to the key, This PR should fix #146